### PR TITLE
Fix for missing explicit project file override

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -146,7 +146,7 @@ function GetRepoInfo([string] $pathToRepo, [string] $entryProjectOverride = $nul
             $repoInfo.SolutionFile = Combine $repoInfo.RepoDirectory $repoInfo.SolutionFile
         }
 
-        $actualEntryProjectFile = if ($null -ne $entryProjectOverride)
+        $actualEntryProjectFile = if ($entryProjectOverride)
         {
             $entryProjectOverride
         }
@@ -159,7 +159,7 @@ function GetRepoInfo([string] $pathToRepo, [string] $entryProjectOverride = $nul
             $null
         }
 
-        $repoInfo | Add-Member -MemberType NoteProperty -Name `EntryProjectFile` -Value $actualEntryProjectFile
+        $repoInfo | Add-Member -NotePropertyName EntryProjectFile -NotePropertyValue $actualEntryProjectFile
 
         return $repoInfo
     }


### PR DESCRIPTION
* Properly check if the entry project override is null or empty
* Set the property name so it can be accessed in the usual way