### PR TITLE
fix branch names

### DIFF
--- a/scripts/BuildRepos.ps1
+++ b/scripts/BuildRepos.ps1
@@ -3,9 +3,9 @@ param (
     [switch]$BuildMSBuild,
     [switch]$RedirectEnvironmentToBuildOutputs,
     [string]$Repos,
-    [string]$MSBuildBranch = "master",
+    [string]$MSBuildBranch = "origin/master",
     [string]$MSBuildRepoAddress = "https://github.com/microsoft/msbuild.git",
-    [string]$SDKBranch = "master",
+    [string]$SDKBranch = "origin/master",
     [string]$SDKRepoAddress = "https://github.com/dotnet/sdk.git",
     [string]$Configuration = "Release"
 )


### PR DESCRIPTION
Need to reference remote in order for the repo to sync with latest changes. Otherwise it checks out its local version of the branch which is stale.